### PR TITLE
Corrección de la razón social en el formulario

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # PrestaShoppCFDI33_1.7
 Plugin Prestashop 1.7 para nuevo cfdi 3.3
 
+### Fix v3.3.2
+ * Fix en la captura de la razón social del formulario.
+
 ### Fix v3.3.1
  * Fix en bug de tab name en los idiomas al momento de instalar.
 

--- a/blockfactura/views/templates/front/factura.tpl
+++ b/blockfactura/views/templates/front/factura.tpl
@@ -104,7 +104,7 @@
 				<div class="row">
 					<div class="col-md-6">
 						<div class="form-group">
-							<input id="data-razonsocial" type="text" class="client-input animacion-input" name="data-razoncial" disabled="true" style="border-color: {$colors|escape:'htmlall':'UTF-8'};">
+							<input id="data-razonsocial" type="text" class="client-input animacion-input" name="data-razonsocial" disabled="true" style="border-color: {$colors|escape:'htmlall':'UTF-8'};">
 							<label for="rfc">{l s='Business name' mod='blockfactura'}</label>
 						</div>
 					</div>


### PR DESCRIPTION
La propiedad name del formulario que captura la información del receptor tiene mal la etiqueta de la razón social.
Esto provoca que no se capture bien el cliente, pues no manda este dato y aparece vació al momento de timbrar.