### PR TITLE
Modificación en descuentos, se evita la asignación de descuento = 0

### DIFF
--- a/blockfactura/controllers/front/process.php
+++ b/blockfactura/controllers/front/process.php
@@ -318,7 +318,7 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
         //$products_invoice = Cookies::getCookie('order');
         $products_invoice = array();
         $flag_discount = false;
-
+        $emptyDiscount = false;  //bandera para indicar que hay descuento a aplicar
         $order_id = (int) $this->context->cookie->Order;
         $discount = (float) $this->context->cookie->Discount;
         $order = new Order($order_id);
@@ -359,13 +359,18 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
             if($flag_discount) {
               $set_discount = 0;
             } else {
-              if($discount > $unit_price * $product['product_quantity'] || $discount == 0) {
-                $set_discount = 0;
-                $flag_discount = false;
-              } else {
-                $set_discount = $discount;
-                $flag_discount = true;
-              }
+                if($discount == 0){
+                    $set_discount = 0;
+                    $flag_discount = true;
+                } else if ($discount > $unit_price * $product['product_quantity']){
+                    $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
+                    $discount -= ($unit_price * $product['product_quantity'])-0.01;
+                    $emptyDiscount = true;
+                } else {
+                    $set_discount = $discount;
+                    $discount = 0;
+                    $emptyDiscount = true;
+                }
             }
          
             //armar los impuestos por producto
@@ -410,6 +415,10 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
               unset($products_invoice[$in]['Impuestos']);
             }
             $in++;
+        }
+
+        if($discount > 0 && $emptyDiscount){
+            return die(Tools::jsonEncode(array('response' => 'error', 'message' => 'El descuento no debe ser mayor al subtotal')));
         }
 
         //método para obtener los gastos de envío

--- a/blockfactura/controllers/front/process.php
+++ b/blockfactura/controllers/front/process.php
@@ -366,6 +366,10 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
                     $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
                     $discount -= ($unit_price * $product['product_quantity'])-0.01;
                     $emptyDiscount = true;
+                } else if($discount == $unit_price * $product['product_quantity']){
+                    $set_discount = ($unit_price * $product['product_quantity'])-0.01; //se evita tener campo base traslado igual a 0
+                    $discount = 0;
+                    $emptyDiscount = true;
                 } else {
                     $set_discount = $discount;
                     $discount = 0;


### PR DESCRIPTION
Se modificó la parte de descuentos para que el descuento tome casi el valor total de cada producto (en caso de que éste sea mayor), esto con el fin de evitar el error de timbrado de ‘El valor campo base que corresponde a Traslado debe ser mayor que cero’.