### PR TITLE
Implementacion del IVA 8% para plugin V.1.7

### DIFF
--- a/blockfactura/controllers/front/process.php
+++ b/blockfactura/controllers/front/process.php
@@ -397,6 +397,24 @@ class BlockfacturaProcessModuleFrontController extends ModuleFrontController
                 $traslados = array('Traslados' => $taxes_product);
               break;
 
+              case 8:
+                $base_calc = (Tools::ps_round($unit_price, 2) * $product['product_quantity']) - $set_discount;
+                $decimas = explode(".", $base_calc);
+
+                //verificamos que no exceda el máximo de decimales
+                if(strlen($decimas[1]) > 6) {
+                    $base_calc = round($base_calc, 6);
+                }
+                $taxes_product[] = array(
+                  'Base' => $base_calc,
+                  'Impuesto' => '002',
+                  'TipoFactor' => 'Tasa',
+                  'TasaOCuota' => '0.08',
+                  'Importe' => Tools::ps_round($base_calc * .08, 6)
+                );
+                $traslados = array('Traslados' => $taxes_product);
+              break;
+
               default:
                 $traslados = [];
                 break;


### PR DESCRIPTION
Se implementó el caso para los productos que tengas IVA 8% en el plugin de prestashop versión 1.7, ya que sólo está el caso para los productos que tienen el 16%